### PR TITLE
Add tasks store using Dexie

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,43 @@
+import Dexie, { type Table } from 'dexie';
+
+export interface Task {
+  id: string;
+  title: string;
+  dueAt: number | null;
+  durationMin: number | null;
+  categoryId: string | null;
+  status: 'pending' | 'done';
+  checklist: { id: string; text: string; checked: boolean }[];
+  repeatRule: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface Category {
+  id: string;
+  name: string;
+  color: string;
+  order: number;
+}
+
+export interface Setting {
+  key: string;
+  value: unknown;
+}
+
+class TodoDB extends Dexie {
+  tasks!: Table<Task>;
+  categories!: Table<Category>;
+  settings!: Table<Setting>;
+
+  constructor() {
+    super('todo');
+    this.version(1).stores({
+      tasks: 'id,status,dueAt',
+      categories: 'id,order',
+      settings: 'key',
+    });
+  }
+}
+
+export const db = new TodoDB();

--- a/src/store/__tests__/useTasks.test.ts
+++ b/src/store/__tests__/useTasks.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useTasks } from '../useTasks';
+import type { Task } from '../../db';
+
+const tasks: Task[] = [];
+
+vi.mock('../../db', () => ({
+  db: {
+    tasks: {
+      toArray: () => Promise.resolve([...tasks]),
+      add: (task: Task) => {
+        tasks.push(task);
+        return Promise.resolve();
+      },
+    },
+  },
+}));
+
+describe('useTasks store', () => {
+  beforeEach(() => {
+    tasks.length = 0;
+  });
+
+  it('adds a task', async () => {
+    const draft = {
+      title: 'test',
+      dueAt: null,
+      durationMin: null,
+      categoryId: null,
+      checklist: [],
+      repeatRule: null,
+    };
+    const id = await useTasks.getState().add(draft);
+    expect(id).toBeDefined();
+    expect(useTasks.getState().tasks).toHaveLength(1);
+    expect(useTasks.getState().tasks[0].title).toBe('test');
+  });
+
+  it('loads tasks', async () => {
+    tasks.push({
+      id: '1',
+      title: 'loaded',
+      dueAt: null,
+      durationMin: null,
+      categoryId: null,
+      status: 'pending',
+      checklist: [],
+      repeatRule: null,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    await useTasks.getState().load();
+    expect(useTasks.getState().tasks).toHaveLength(1);
+    expect(useTasks.getState().tasks[0].title).toBe('loaded');
+  });
+});

--- a/src/store/useTasks.ts
+++ b/src/store/useTasks.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand';
+import { db, type Task } from '../db';
+
+export interface TaskDraft {
+  title: string;
+  dueAt: number | null;
+  durationMin: number | null;
+  categoryId: string | null;
+  checklist: { id: string; text: string; checked: boolean }[];
+  repeatRule: string | null;
+}
+
+export interface TaskStore {
+  tasks: Task[];
+  load: () => Promise<void>;
+  add: (draft: TaskDraft) => Promise<string>;
+}
+
+function scheduleReminder(task: Task) {
+  void task;
+  // TODO: implement Service Worker notification
+}
+
+export const useTasks = create<TaskStore>((set, get) => ({
+  tasks: [],
+  async load() {
+    const all = await db.tasks.toArray();
+    set({ tasks: all });
+  },
+  async add(draft) {
+    const id = crypto.randomUUID();
+    const now = Date.now();
+    const task: Task = {
+      id,
+      status: 'pending',
+      createdAt: now,
+      updatedAt: now,
+      ...draft,
+    };
+    await db.tasks.add(task);
+    set({ tasks: [...get().tasks, task] });
+    scheduleReminder(task);
+    return id;
+  },
+}));


### PR DESCRIPTION
## Summary
- add IndexedDB wrapper via Dexie
- implement Zustand task store
- cover store with unit tests

## Testing
- `npm run lint`
- `npm test`
