### PR TITLE
Add service worker notifications

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { registerSW } from 'virtual:pwa-register';
+
+registerSW({ immediate: true });
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/store/useTasks.ts
+++ b/src/store/useTasks.ts
@@ -17,8 +17,21 @@ export interface TaskStore {
 }
 
 function scheduleReminder(task: Task) {
-  void task;
-  // TODO: implement Service Worker notification
+  if (!task.dueAt || !('serviceWorker' in navigator)) {
+    return;
+  }
+
+  if (Notification.permission === 'default') {
+    void Notification.requestPermission();
+  }
+
+  navigator.serviceWorker.ready
+    .then((reg) => {
+      reg.active?.postMessage({ type: 'SCHEDULE', task });
+    })
+    .catch(() => {
+      // noop
+    });
 }
 
 export const useTasks = create<TaskStore>((set, get) => ({

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,0 +1,32 @@
+/// <reference lib="webworker" />
+
+self.addEventListener('message', (e) => {
+  if (e.data?.type === 'SCHEDULE') {
+    schedule(e.data.task);
+  }
+});
+
+function schedule(task: { id: string; title: string; dueAt: number }) {
+  const diff = task.dueAt - Date.now();
+  setTimeout(() => {
+    self.registration.showNotification(task.title, {
+      body: '期限です',
+      tag: task.id,
+      actions: [{ action: 'snooze', title: '後で' }],
+      data: task,
+    });
+  }, diff);
+}
+
+self.addEventListener('notificationclick', (event) => {
+  const notification = event.notification;
+  const task = notification.data;
+  if (event.action === 'snooze') {
+    notification.close();
+    schedule({ ...task, dueAt: Date.now() + 5 * 60 * 1000 });
+    return;
+  }
+  event.waitUntil(clients.openWindow('/'));
+  notification.close();
+});
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: 'prompt',
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'sw.ts',
       includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'mask-icon.svg'],
       manifest: {
         name: 'Todo Claude',


### PR DESCRIPTION
## Summary
- schedule reminders to Service Worker
- register service worker in the app
- implement Service Worker logic for notifications
- configure Vite PWA with injectManifest
- test reminder scheduling

## Testing
- `npm run lint`
- `npm test`
