### PR TITLE
Add settings store

### DIFF
--- a/src/store/__tests__/useSettings.test.ts
+++ b/src/store/__tests__/useSettings.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useSettings } from '../useSettings';
+
+const settings: Record<string, unknown> = {};
+
+vi.mock('../../db', () => ({
+  db: {
+    settings: {
+      toArray: () =>
+        Promise.resolve(
+          Object.entries(settings).map(([key, value]) => ({ key, value })),
+        ),
+      put: ({ key, value }: { key: string; value: unknown }) => {
+        settings[key] = value;
+        return Promise.resolve();
+      },
+    },
+  },
+}));
+
+describe('useSettings store', () => {
+  beforeEach(() => {
+    for (const k of Object.keys(settings)) delete settings[k];
+    useSettings.setState({
+      settings: {
+        notifyBeforeMin: 10,
+        theme: 'light',
+        snoozeMin: 5,
+      },
+    });
+  });
+
+  it('loads settings', async () => {
+    settings.theme = 'dark';
+    await useSettings.getState().load();
+    expect(useSettings.getState().settings.theme).toBe('dark');
+  });
+
+  it('updates setting', async () => {
+    await useSettings.getState().update('notifyBeforeMin', 15);
+    expect(settings.notifyBeforeMin).toBe(15);
+    expect(useSettings.getState().settings.notifyBeforeMin).toBe(15);
+  });
+});

--- a/src/store/__tests__/useTasks.test.ts
+++ b/src/store/__tests__/useTasks.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../db', () => ({
 describe('useTasks store', () => {
   beforeEach(() => {
     tasks.length = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global as any).Notification = {
       permission: 'granted',
       requestPermission: vi.fn(() => Promise.resolve('granted')),

--- a/src/store/useSettings.ts
+++ b/src/store/useSettings.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+import { db } from '../db';
+
+export interface Settings {
+  notifyBeforeMin: number;
+  theme: 'light' | 'dark';
+  snoozeMin: number;
+}
+
+export interface SettingsStore {
+  settings: Settings;
+  load: () => Promise<void>;
+  update: <K extends keyof Settings>(key: K, value: Settings[K]) => Promise<void>;
+}
+
+const DEFAULT_SETTINGS: Settings = {
+  notifyBeforeMin: 10,
+  theme: 'light',
+  snoozeMin: 5,
+};
+
+export const useSettings = create<SettingsStore>((set, get) => ({
+  settings: DEFAULT_SETTINGS,
+  async load() {
+    const entries = await db.settings.toArray();
+    const loaded: Settings = { ...DEFAULT_SETTINGS };
+    for (const { key, value } of entries) {
+      if (key in loaded) {
+        loaded[key as keyof Settings] = value as Settings[keyof Settings];
+      }
+    }
+    set({ settings: loaded });
+  },
+  async update(key, value) {
+    await db.settings.put({ key, value });
+    set({ settings: { ...get().settings, [key]: value } });
+  },
+}));


### PR DESCRIPTION
## Summary
- manage user preferences with new `useSettings` store
- cover settings store with tests
- fix lint warning in existing tasks store test

## Testing
- `npm run lint`
- `npm test -- --run`
