### PR TITLE
feat: add categories store

### DIFF
--- a/src/components/CategoryBadge.tsx
+++ b/src/components/CategoryBadge.tsx
@@ -1,0 +1,20 @@
+import type { Category } from '../db';
+
+interface Props {
+  category: Category;
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+export function CategoryBadge({ category, selected, onClick }: Props) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-2 py-1 rounded-full text-white text-sm ${selected ? 'opacity-100' : 'opacity-60'}`}
+      style={{ backgroundColor: category.color }}
+    >
+      {category.name}
+    </button>
+  );
+}

--- a/src/store/__tests__/useCategories.test.ts
+++ b/src/store/__tests__/useCategories.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useCategories } from '../useCategories';
+import type { Category } from '../../db';
+
+const categories: Category[] = [];
+
+vi.mock('../../db', () => ({
+  db: {
+    categories: {
+      orderBy: () => ({
+        toArray: () => Promise.resolve([...categories].sort((a, b) => a.order - b.order)),
+      }),
+      add: (cat: Category) => {
+        categories.push(cat);
+        return Promise.resolve();
+      },
+      put: (cat: Category) => {
+        const idx = categories.findIndex((c) => c.id === cat.id);
+        if (idx >= 0) categories[idx] = cat;
+        return Promise.resolve();
+      },
+    },
+    transaction: (_mode: string, _table: unknown, cb: () => Promise<void>) => cb(),
+  },
+}));
+
+describe('useCategories store', () => {
+  beforeEach(() => {
+    categories.length = 0;
+    useCategories.setState({ categories: [] });
+  });
+
+  it('adds a category', async () => {
+    const draft = { name: 'Work', color: '#ff0000' };
+    const id = await useCategories.getState().add(draft);
+    expect(id).toBeDefined();
+    expect(useCategories.getState().categories).toHaveLength(1);
+    expect(useCategories.getState().categories[0].name).toBe('Work');
+  });
+
+  it('loads categories sorted by order', async () => {
+    categories.push(
+      { id: '1', name: 'A', color: '#000', order: 1 },
+      { id: '2', name: 'B', color: '#111', order: 0 },
+    );
+    await useCategories.getState().load();
+    const loaded = useCategories.getState().categories;
+    expect(loaded[0].id).toBe('2');
+    expect(loaded[1].id).toBe('1');
+  });
+
+  it('reorders categories', async () => {
+    categories.push(
+      { id: '1', name: 'A', color: '#000', order: 0 },
+      { id: '2', name: 'B', color: '#111', order: 1 },
+    );
+    useCategories.setState({ categories: [...categories] });
+    await useCategories.getState().reorder(['2', '1']);
+    expect(categories[0].order).toBe(1);
+    expect(categories[1].order).toBe(0);
+    const local = useCategories.getState().categories;
+    expect(local[0].id).toBe('2');
+    expect(local[1].id).toBe('1');
+  });
+});

--- a/src/store/useCategories.ts
+++ b/src/store/useCategories.ts
@@ -1,0 +1,53 @@
+import { create } from 'zustand';
+import { db, type Category } from '../db';
+
+export interface CategoryDraft {
+  name: string;
+  color: string;
+}
+
+export interface CategoriesStore {
+  categories: Category[];
+  load: () => Promise<void>;
+  add: (draft: CategoryDraft) => Promise<string>;
+  reorder: (ids: string[]) => Promise<void>;
+}
+
+export const useCategories = create<CategoriesStore>((set, get) => ({
+  categories: [],
+  async load() {
+    const all = await db.categories.orderBy('order').toArray();
+    set({ categories: all });
+  },
+  async add(draft) {
+    const id = crypto.randomUUID();
+    const order = get().categories.length;
+    const category: Category = { id, order, ...draft };
+    await db.categories.add(category);
+    set({ categories: [...get().categories, category] });
+    return id;
+  },
+  async reorder(ids) {
+    const updates: Category[] = [];
+    const current = get().categories;
+    const map = new Map(current.map((c) => [c.id, c]));
+    ids.forEach((id, index) => {
+      const cat = map.get(id);
+      if (cat && cat.order !== index) {
+        const updated = { ...cat, order: index };
+        updates.push(updated);
+      }
+    });
+    await db.transaction('rw', db.categories, async () => {
+      for (const cat of updates) {
+        await db.categories.put(cat);
+      }
+    });
+    const reordered = ids
+      .map((id, index) => {
+        const cat = map.get(id)!;
+        return { ...cat, order: index };
+      });
+    set({ categories: reordered });
+  },
+}));


### PR DESCRIPTION
## Summary
- add `useCategories` store for managing Category entities
- include reorder functionality
- create simple `CategoryBadge` component
- add unit tests for the new store

## Testing
- `npm run lint`
- `npx vitest run`
