### PR TITLE
Fix build by removing unused React imports and adding missing types

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { RouterProvider } from 'react-router-dom';
 import { router } from './routes';
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { Navbar } from './Navbar';
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
 import { useUI } from '../store/useUI';
 

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Task } from '../db';
 
 interface Props {

--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { useTasks } from '../store/useTasks';
 
 export function TaskForm() {
   const add = useTasks((s) => s.add);
   const [title, setTitle] = useState('');
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (!title.trim()) return;
     await add({

--- a/src/components/__tests__/Navbar.test.tsx
+++ b/src/components/__tests__/Navbar.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { renderToString } from 'react-dom/server';
 import { MemoryRouter } from 'react-router-dom';

--- a/src/components/__tests__/TaskCard.test.tsx
+++ b/src/components/__tests__/TaskCard.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { renderToString } from 'react-dom/server';
 import { TaskCard } from '../TaskCard';

--- a/src/components/__tests__/TaskForm.test.tsx
+++ b/src/components/__tests__/TaskForm.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { renderToString } from 'react-dom/server';
 import { TaskForm } from '../TaskForm';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
 import App from './App.tsx';
 import './index.css';
 import { registerSW } from 'virtual:pwa-register';
@@ -7,7 +7,7 @@ import { registerSW } from 'virtual:pwa-register';
 registerSW({ immediate: true });
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/src/pages/AllTasksPage.tsx
+++ b/src/pages/AllTasksPage.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect } from 'react';
 import { TaskCard } from '../components/TaskCard';
 import { TaskForm } from '../components/TaskForm';
 import { useTasks } from '../store/useTasks';
+import { useEffect } from 'react';
 
 export default function AllTasksPage() {
   const tasks = useTasks((s) => s.tasks);

--- a/src/pages/CategoriesPage.tsx
+++ b/src/pages/CategoriesPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export default function CategoriesPage() {
   return (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export default function HomePage() {
   return (

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export default function SettingsPage() {
   return (

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 import Layout from './components/Layout';
 import HomePage from './pages/HomePage';

--- a/src/store/__tests__/useTasks.test.ts
+++ b/src/store/__tests__/useTasks.test.ts
@@ -20,7 +20,7 @@ describe('useTasks store', () => {
   beforeEach(() => {
     tasks.length = 0;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).Notification = {
+    (globalThis as any).Notification = {
       permission: 'granted',
       requestPermission: vi.fn(() => Promise.resolve('granted')),
     };
@@ -44,7 +44,7 @@ describe('useTasks store', () => {
   it('schedules reminder via service worker', async () => {
     const postMessage = vi.fn();
     const ready = Promise.resolve({ active: { postMessage } });
-    Object.defineProperty(global.navigator, 'serviceWorker', {
+    Object.defineProperty(globalThis.navigator, 'serviceWorker', {
       value: { ready },
       configurable: true,
     });

--- a/src/store/useSettings.ts
+++ b/src/store/useSettings.ts
@@ -25,8 +25,16 @@ export const useSettings = create<SettingsStore>((set, get) => ({
     const entries = await db.settings.toArray();
     const loaded: Settings = { ...DEFAULT_SETTINGS };
     for (const { key, value } of entries) {
-      if (key in loaded) {
-        loaded[key as keyof Settings] = value as Settings[keyof Settings];
+      switch (key) {
+        case 'notifyBeforeMin':
+        case 'snoozeMin':
+          loaded[key] = Number(value) as Settings[typeof key];
+          break;
+        case 'theme':
+          loaded.theme = value === 'dark' ? 'dark' : 'light';
+          break;
+        default:
+          break;
       }
     }
     set({ settings: loaded });

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module 'virtual:pwa-register' {
+  import type { RegisterSWOptions } from 'vite-plugin-pwa/types';
+  export type { RegisterSWOptions };
+  export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void>;
+}


### PR DESCRIPTION
## Summary
- clean up unused React imports across app and tests
- handle loading settings with explicit switch cases
- add vite env types and adjust main entry
- type service worker correctly

## Testing
- `npm run type-check`
- `npm run lint`
- `npm test`