### PR TITLE
Fix base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { VitePWA } from 'vite-plugin-pwa';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/todo-codex/',
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
## Summary
- set `base` option in `vite.config.ts` so that built files resolve correctly on `https://static.fbbp.dev/todo-codex/`

## Testing
- `npm test -- --run`
- `npm run lint`
