### PR TITLE
Add export/import support

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,6 +1,52 @@
 
+import { exportData, importData } from '../utils/exportImport';
+import { useTasks } from '../store/useTasks';
+import { useCategories } from '../store/useCategories';
+import { useSettings } from '../store/useSettings';
+
 export default function SettingsPage() {
+  const reload = async () => {
+    await Promise.all([
+      useTasks.getState().load(),
+      useCategories.getState().load(),
+      useSettings.getState().load(),
+    ]);
+  };
+
+  const handleExport = async () => {
+    const data = await exportData();
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'todo-export.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    await importData(JSON.parse(text));
+    await reload();
+  };
+
   return (
-    <div className="p-4">Settings Page</div>
+    <div className="p-4 space-y-4">
+      <button
+        type="button"
+        onClick={handleExport}
+        className="rounded-full shadow px-4 py-2 font-semibold bg-primary text-white"
+      >
+        Export
+      </button>
+      <label className="block">
+        <span className="mr-2">Import</span>
+        <input type="file" accept="application/json" onChange={handleImport} />
+      </label>
+    </div>
   );
 }

--- a/src/store/__tests__/useTasks.test.ts
+++ b/src/store/__tests__/useTasks.test.ts
@@ -24,8 +24,10 @@ describe('useTasks store', () => {
       permission: 'granted',
       requestPermission: vi.fn(() => Promise.resolve('granted')),
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (globalThis as any).navigator = {};
+    Object.defineProperty(globalThis, 'navigator', {
+      value: {},
+      configurable: true,
+    });
   });
 
   it('adds a task', async () => {

--- a/src/utils/__tests__/exportImport.test.ts
+++ b/src/utils/__tests__/exportImport.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { exportData, importData, type ExportData } from '../exportImport';
+import type { Task, Category, Setting } from '../../db';
+
+const tasks: Task[] = [];
+const categories: Category[] = [];
+const settings: Setting[] = [];
+
+vi.mock('../../db', () => ({
+  db: {
+    tasks: {
+      toArray: () => Promise.resolve([...tasks]),
+      clear: () => {
+        tasks.length = 0;
+        return Promise.resolve();
+      },
+      bulkAdd: (items: Task[]) => {
+        tasks.push(...items);
+        return Promise.resolve();
+      },
+    },
+    categories: {
+      toArray: () => Promise.resolve([...categories]),
+      clear: () => {
+        categories.length = 0;
+        return Promise.resolve();
+      },
+      bulkAdd: (items: Category[]) => {
+        categories.push(...items);
+        return Promise.resolve();
+      },
+    },
+    settings: {
+      toArray: () => Promise.resolve([...settings]),
+      clear: () => {
+        settings.length = 0;
+        return Promise.resolve();
+      },
+      bulkAdd: (items: Setting[]) => {
+        settings.push(...items);
+        return Promise.resolve();
+      },
+    },
+    transaction: (_mode: string, _t1: unknown, _t2: unknown, _t3: unknown, cb: () => Promise<void>) => cb(),
+  },
+}));
+
+beforeEach(() => {
+  tasks.length = 0;
+  categories.length = 0;
+  settings.length = 0;
+});
+
+describe('export/import data', () => {
+  it('exports current db contents', async () => {
+    tasks.push({
+      id: 't',
+      title: 'task',
+      dueAt: null,
+      durationMin: null,
+      categoryId: null,
+      status: 'pending',
+      checklist: [],
+      repeatRule: null,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    const data = await exportData();
+    expect(data.tasks).toHaveLength(1);
+    expect(data.categories).toHaveLength(0);
+  });
+
+  it('imports data by replacing existing records', async () => {
+    tasks.push({
+      id: 'old',
+      title: 'old',
+      dueAt: null,
+      durationMin: null,
+      categoryId: null,
+      status: 'pending',
+      checklist: [],
+      repeatRule: null,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    const data: ExportData = {
+      tasks: [
+        {
+          id: 'new',
+          title: 'new',
+          dueAt: null,
+          durationMin: null,
+          categoryId: null,
+          status: 'pending',
+          checklist: [],
+          repeatRule: null,
+          createdAt: 0,
+          updatedAt: 0,
+        },
+      ],
+      categories: [],
+      settings: [],
+    };
+    await importData(data);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].id).toBe('new');
+  });
+});

--- a/src/utils/exportImport.ts
+++ b/src/utils/exportImport.ts
@@ -1,0 +1,27 @@
+import { db, type Task, type Category, type Setting } from '../db';
+
+export interface ExportData {
+  tasks: Task[];
+  categories: Category[];
+  settings: Setting[];
+}
+
+export async function exportData(): Promise<ExportData> {
+  const [tasks, categories, settings] = await Promise.all([
+    db.tasks.toArray(),
+    db.categories.toArray(),
+    db.settings.toArray(),
+  ]);
+  return { tasks, categories, settings };
+}
+
+export async function importData(data: ExportData): Promise<void> {
+  await db.transaction('rw', db.tasks, db.categories, db.settings, async () => {
+    await db.tasks.clear();
+    await db.categories.clear();
+    await db.settings.clear();
+    if (data.tasks.length) await db.tasks.bulkAdd(data.tasks);
+    if (data.categories.length) await db.categories.bulkAdd(data.categories);
+    if (data.settings.length) await db.settings.bulkAdd(data.settings);
+  });
+}


### PR DESCRIPTION
## Summary
- implement `exportData` and `importData` utilities
- add export/import UI on settings page
- fix `useTasks` test environment
- test new utilities

## Testing
- `npm run lint`
- `CI=1 npm test`
