### PR TITLE
Add E2E and a11y tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,11 @@ jobs:
         with:
           version: 9
       - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps
       - run: pnpm run lint
       - run: pnpm run test
+      - run: pnpm run test:e2e
+      - run: pnpm run test:a11y
       - run: pnpm run build
       
       # Deploy to Pages

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test:ci": "vitest run --passWithNoTests",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
+    "test:e2e": "playwright test tests/e2e",
+    "test:a11y": "playwright test tests/a11y",
     "type-check": "tsc --noEmit",
     "prepare": "husky"
   },
@@ -44,6 +46,8 @@
     "vite": "^5.3.4",
     "vite-plugin-pwa": "^0.20.5",
     "vitest": "^2.0.0",
+    "@playwright/test": "^1.40.0",
+    "@axe-core/playwright": "^4.7.2",
     "workbox-window": "^7.1.0"
   },
   "simple-git-hooks": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        browserName: 'chromium',
+        baseURL: 'http://localhost:4173',
+        headless: true,
+        offline: true,
+        permissions: ['notifications'],
+      },
+    },
+  ],
+  webServer: {
+    command: 'pnpm run preview',
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/a11y/homeA11y.spec.ts
+++ b/tests/a11y/homeA11y.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test('home page passes accessibility checks', async ({ page }) => {
+  await page.goto('/');
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('home page displays content', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('body')).toContainText('Home Page');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": ["src", "tests"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- add Playwright setup and Axe integration
- run e2e & a11y tests in CI
- update tsconfig includes

## Testing
- `pnpm run lint` *(fails: ESLint couldn't find config)*
- `pnpm run test` *(fails: vitest not found)*
- `pnpm run test:e2e` *(fails: playwright not found)*
- `pnpm run test:a11y` *(fails: playwright not found)*