### PR TITLE
Add Workbox offline support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.1",
     "workbox-precaching": "^7.3.0",
+    "workbox-core": "^7.3.0",
+    "workbox-routing": "^7.3.0",
+    "workbox-strategies": "^7.3.0",
     "zustand": "^4.5.5"
   },
   "devDependencies": {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,13 +1,25 @@
 /// <reference lib="webworker" />
 
 import { precacheAndRoute } from 'workbox-precaching';
+import { clientsClaim } from 'workbox-core';
+import { registerRoute } from 'workbox-routing';
+import { NetworkFirst } from 'workbox-strategies';
 
 declare let self: ServiceWorkerGlobalScope & { __WB_MANIFEST: unknown };
 
 const sw = self as unknown as ServiceWorkerGlobalScope;
 
+sw.skipWaiting();
+clientsClaim();
+
 // precache assets injected by Vite PWA
 precacheAndRoute(self.__WB_MANIFEST);
+
+// offline fallback for navigation requests
+registerRoute(
+  ({ request }) => request.mode === 'navigate',
+  new NetworkFirst({ cacheName: 'pages' }),
+);
 
 sw.addEventListener('message', (e) => {
   if (e.data?.type === 'SCHEDULE') {


### PR DESCRIPTION
## Summary
- use workbox-core and friends in service worker
- precache assets and handle navigation requests offline
- add workbox packages to dependencies

## Testing
- `pnpm run type-check`
- `pnpm lint`
- `pnpm test:run`
