### PR TITLE
Add next task display and reminder settings

### DIFF
--- a/src/components/NextTask.tsx
+++ b/src/components/NextTask.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { useTasks } from '../store/useTasks';
+
+interface Props {
+  tasks?: ReturnType<typeof useTasks.getState>['tasks'];
+}
+export function NextTask({ tasks: override }: Props = {}) {
+  const storeTasks = useTasks((s) => s.tasks);
+  const tasks = override ?? storeTasks;
+  const load = useTasks((s) => s.load);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const now = Date.now();
+  const next = tasks
+    .filter((t) => t.status === 'pending' && t.dueAt && t.dueAt >= now)
+    .sort((a, b) => (a.dueAt ?? 0) - (b.dueAt ?? 0))[0];
+
+  if (!next) {
+    return <div className="text-slate-500">No upcoming tasks</div>;
+  }
+
+  return (
+    <div className="rounded-2xl p-4 shadow-sm bg-white space-y-1">
+      <div className="text-xl font-semibold">{next.title}</div>
+      {next.dueAt && (
+        <time
+          dateTime={new Date(next.dueAt).toISOString()}
+          className="text-sm text-slate-500"
+        >
+          {new Date(next.dueAt).toLocaleTimeString()}
+        </time>
+      )}
+    </div>
+  );
+}

--- a/src/components/__tests__/NextTask.test.tsx
+++ b/src/components/__tests__/NextTask.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import { NextTask } from '../NextTask';
+
+// simple mock for tasks state
+describe('NextTask', () => {
+  it('renders the nearest upcoming task', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+    const tasks = [
+      {
+        id: '1',
+        title: 'first',
+        dueAt: Date.now() + 60 * 60 * 1000,
+        durationMin: null,
+        categoryId: null,
+        status: 'pending' as const,
+        checklist: [],
+        repeatRule: null,
+        createdAt: 0,
+        updatedAt: 0,
+      },
+      {
+        id: '2',
+        title: 'later',
+        dueAt: Date.now() + 2 * 60 * 60 * 1000,
+        durationMin: null,
+        categoryId: null,
+        status: 'pending' as const,
+        checklist: [],
+        repeatRule: null,
+        createdAt: 0,
+        updatedAt: 0,
+      },
+    ];
+    const html = renderToString(<NextTask tasks={tasks} />);
+    expect(html).toContain('first');
+    vi.useRealTimers();
+  });
+});

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,10 +1,12 @@
 
 import { TimelineBar } from '../components/TimelineBar';
+import { NextTask } from '../components/NextTask';
 
 export default function HomePage() {
   return (
     <div className="space-y-4 p-4">
       <TimelineBar />
+      <NextTask />
     </div>
   );
 }

--- a/src/store/__tests__/useTasks.test.ts
+++ b/src/store/__tests__/useTasks.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useTasks } from '../useTasks';
+import { useSettings } from '../useSettings';
 import type { Task } from '../../db';
 
 const tasks: Task[] = [];
@@ -56,6 +57,10 @@ describe('useTasks store', () => {
       configurable: true,
     });
 
+    useSettings.setState({
+      settings: { notifyBeforeMin: 1, theme: 'light', snoozeMin: 5 },
+    });
+
     const draft = {
       title: 'due task',
       dueAt: Date.now() + 1000,
@@ -67,7 +72,10 @@ describe('useTasks store', () => {
 
     await useTasks.getState().add(draft);
     await ready;
-    expect(postMessage).toHaveBeenCalledWith({ type: 'SCHEDULE', task: expect.any(Object) });
+    const sent = postMessage.mock.calls[0][0];
+    expect(sent.type).toBe('SCHEDULE');
+    expect(sent.task.dueAt).toBeCloseTo(draft.dueAt - 60 * 1000, -2);
+    expect(sent.task.snoozeMin).toBe(5);
   });
 
   it('loads tasks', async () => {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -27,7 +27,7 @@ sw.addEventListener('message', (e) => {
   }
 });
 
-function schedule(task: { id: string; title: string; dueAt: number }) {
+function schedule(task: { id: string; title: string; dueAt: number; snoozeMin: number }) {
   const diff = task.dueAt - Date.now();
   setTimeout(() => {
     sw.registration.showNotification(
@@ -47,7 +47,7 @@ sw.addEventListener('notificationclick', (event: NotificationEvent) => {
   const task = notification.data;
   if (event.action === 'snooze') {
     notification.close();
-    schedule({ ...task, dueAt: Date.now() + 5 * 60 * 1000 });
+    schedule({ ...task, dueAt: Date.now() + task.snoozeMin * 60 * 1000 });
     return;
   }
   event.waitUntil(sw.clients.openWindow('/'));


### PR DESCRIPTION
## Summary
- show upcoming task on Home page
- schedule reminders with user settings
- support snooze duration in Service Worker
- add NextTask component and tests

## Testing
- `pnpm lint`
- `pnpm test:run`
