### PR TITLE
Add repeat rule input to task form

### DIFF
--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -1,65 +1,33 @@
-import { FormEvent, useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTasks } from '../store/useTasks';
+import { useCategories } from '../store/useCategories';
+import { TaskForm } from './TaskForm';
 
 export default function TaskModal() {
   const { id } = useParams();
   const navigate = useNavigate();
   const tasks = useTasks((s) => s.tasks);
-  const load = useTasks((s) => s.load);
-  const add = useTasks((s) => s.add);
-  const update = useTasks((s) => s.update);
-
-  const [title, setTitle] = useState('');
+  const loadTasks = useTasks((s) => s.load);
+  const loadCategories = useCategories((s) => s.load);
 
   useEffect(() => {
-    void load();
-  }, [load]);
+    void loadTasks();
+    void loadCategories();
+  }, [loadTasks, loadCategories]);
 
-  useEffect(() => {
-    if (id) {
-      const t = tasks.find((task) => task.id === id);
-      if (t) setTitle(t.title);
-    }
-  }, [id, tasks]);
-
-  async function handleSubmit(e: FormEvent) {
-    e.preventDefault();
-    const trimmed = title.trim();
-    if (!trimmed) return;
-    if (id) {
-      await update(id, { title: trimmed });
-    } else {
-      await add({
-        title: trimmed,
-        dueAt: null,
-        durationMin: null,
-        categoryId: null,
-        checklist: [],
-        repeatRule: null,
-      });
-    }
-    navigate(-1);
-  }
+  const task = id ? tasks.find((t) => t.id === id) : undefined;
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
-      <form onSubmit={handleSubmit} className="bg-white p-4 rounded-2xl space-y-2 w-80">
-        <input
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          className="border rounded px-2 py-1 w-full"
-          placeholder="Task title"
-        />
-        <div className="flex justify-end gap-2">
+      <div className="bg-white p-4 rounded-2xl space-y-2 w-80">
+        <TaskForm task={task} onSaved={() => navigate(-1)} />
+        <div className="flex justify-end">
           <button type="button" onClick={() => navigate(-1)} className="px-3 py-1 rounded">
             Cancel
           </button>
-          <button type="submit" className="rounded-full shadow px-4 py-1 font-semibold bg-primary text-white">
-            Save
-          </button>
         </div>
-      </form>
+      </div>
     </div>
   );
 }

--- a/src/components/__tests__/TaskForm.test.tsx
+++ b/src/components/__tests__/TaskForm.test.tsx
@@ -1,10 +1,22 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { renderToString } from 'react-dom/server';
 import { TaskForm } from '../TaskForm';
+import type { Category } from '../../db';
+
+vi.mock('../../store/useCategories', () => ({
+  useCategories: (
+    sel?: (s: { categories: Category[]; load: () => void }) => unknown,
+  ) => {
+    const state = { categories: [] as Category[], load: vi.fn() };
+    return sel ? sel(state) : state;
+  },
+}));
 
 describe('TaskForm', () => {
-  it('renders due date field', () => {
+  it('renders form fields', () => {
     const html = renderToString(<TaskForm />);
     expect(html).toContain('datetime-local');
+    expect(html).toContain('<select');
+    expect(html).toContain('RRULE');
   });
 });

--- a/src/components/__tests__/TaskModal.test.tsx
+++ b/src/components/__tests__/TaskModal.test.tsx
@@ -1,7 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { renderToString } from 'react-dom/server';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import TaskModal from '../TaskModal';
+import type { Category } from '../../db';
+
+vi.mock('../../store/useCategories', () => ({
+  useCategories: (
+    sel?: (s: { load: () => void; categories: Category[] }) => unknown,
+  ) => {
+    const state = { load: vi.fn(), categories: [] as Category[] };
+    return sel ? sel(state) : state;
+  },
+}));
 
 describe('TaskModal', () => {
   it('renders save button', () => {


### PR DESCRIPTION
## Summary
- support category & RRULE fields when editing tasks
- reuse `TaskForm` inside modal
- update unit tests

## Testing
- `pnpm run lint`
- `pnpm run test:run`
- `pnpm run build`
