### PR TITLE
Enable light/dark theme switching

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,21 @@
 import { RouterProvider } from 'react-router-dom';
+import { useEffect } from 'react';
 import { router } from './routes';
+import { useSettings } from './store/useSettings';
 
 export default function App() {
+  const theme = useSettings((s) => s.settings.theme);
+  const load = useSettings((s) => s.load);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') root.classList.add('dark');
+    else root.classList.remove('dark');
+  }, [theme]);
+
   return <RouterProvider router={router} />;
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,7 +4,7 @@ import PwaPrompt from './PwaPrompt';
 
 export default function Layout() {
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen">
       <Navbar />
       <main className="p-4">
         <Outlet />

--- a/src/components/NextTask.tsx
+++ b/src/components/NextTask.tsx
@@ -23,7 +23,7 @@ export function NextTask({ tasks: override }: Props = {}) {
   }
 
   return (
-    <div className="rounded-2xl p-4 shadow-sm bg-white space-y-1">
+    <div className="rounded-2xl p-4 shadow-sm bg-white dark:bg-slate-800 space-y-1">
       <div className="text-xl font-semibold">{next.title}</div>
       {next.dueAt && (
         <time

--- a/src/components/PwaPrompt.tsx
+++ b/src/components/PwaPrompt.tsx
@@ -31,7 +31,7 @@ export default function PwaPrompt() {
   return (
     <>
       {(offlineReady || needRefresh) && (
-        <div className="fixed bottom-4 right-4 bg-white shadow p-2 flex gap-2">
+        <div className="fixed bottom-4 right-4 bg-white dark:bg-slate-800 shadow p-2 flex gap-2">
           {offlineReady && <span>Offline ready</span>}
           {needRefresh && (
             <button type="button" onClick={() => updateServiceWorker(true)} className="underline">

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export function TaskCard({ task, category }: Props) {
   return (
-    <div className="rounded-2xl p-4 shadow-sm bg-white space-y-2">
+    <div className="rounded-2xl p-4 shadow-sm bg-white dark:bg-slate-800 space-y-2">
       <div className="flex justify-between items-start">
         <div className="space-y-1">
           <div className="text-xl font-semibold">{task.title}</div>

--- a/src/components/TaskModal.tsx
+++ b/src/components/TaskModal.tsx
@@ -20,7 +20,7 @@ export default function TaskModal() {
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
-      <div className="bg-white p-4 rounded-2xl space-y-2 w-80">
+      <div className="bg-white dark:bg-slate-800 p-4 rounded-2xl space-y-2 w-80">
         <TaskForm task={task} onSaved={() => navigate(-1)} />
         <div className="flex justify-end">
           <button type="button" onClick={() => navigate(-1)} className="px-3 py-1 rounded">

--- a/src/index.css
+++ b/src/index.css
@@ -10,5 +10,15 @@
     --danger: #EF4444;
     --bg-light: #F8FAFC;
     --bg-dark: #1E293B;
+    --bg: var(--bg-light);
+    --text: #0f172a;
+  }
+  .dark {
+    --bg: var(--bg-dark);
+    --text: #F8FAFC;
+  }
+  body {
+    background-color: var(--bg);
+    color: var(--text);
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     './index.html',
     './src/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary
- load user settings in `App` and toggle `dark` class on `<html>`
- set base theme CSS variables and apply them to `body`
- support `darkMode: 'class'` in Tailwind
- remove fixed background color in `Layout`
- add dark backgrounds to cards, modals and prompts

## Testing
- `pnpm lint`
- `pnpm test`