### PR TITLE
Implement dark mode defaults

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,10 @@
     background-color: var(--bg);
     color: var(--text);
   }
+  .dark input,
+  .dark select {
+    color: #000;
+  }
 }
 
 @layer components {

--- a/src/store/__tests__/useSettings.test.ts
+++ b/src/store/__tests__/useSettings.test.ts
@@ -24,7 +24,7 @@ describe('useSettings store', () => {
     useSettings.setState({
       settings: {
         notifyBeforeMin: 10,
-        theme: 'light',
+        theme: 'dark',
         snoozeMin: 5,
       },
     });

--- a/src/store/__tests__/useTasks.test.ts
+++ b/src/store/__tests__/useTasks.test.ts
@@ -63,7 +63,7 @@ describe('useTasks store', () => {
     });
 
     useSettings.setState({
-      settings: { notifyBeforeMin: 1, theme: 'light', snoozeMin: 5 },
+      settings: { notifyBeforeMin: 1, theme: 'dark', snoozeMin: 5 },
     });
 
     const draft = {

--- a/src/store/useSettings.ts
+++ b/src/store/useSettings.ts
@@ -15,7 +15,7 @@ export interface SettingsStore {
 
 const DEFAULT_SETTINGS: Settings = {
   notifyBeforeMin: 10,
-  theme: 'light',
+  theme: 'dark',
   snoozeMin: 5,
 };
 


### PR DESCRIPTION
## Summary
- default to dark theme
- keep input text black in dark mode
- update tests for dark mode defaults

## Testing
- `pnpm lint`
- `pnpm test:run`
