### PR TITLE
Improve desktop UI with shortcuts

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,14 +1,17 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 import { Navbar } from './Navbar';
 import PwaPrompt from './PwaPrompt';
 import OfflineIndicator from './OfflineIndicator';
+import { useKeyboardShortcuts } from '../lib/shortcuts';
 
 export default function Layout() {
+  const navigate = useNavigate();
+  useKeyboardShortcuts(() => navigate('/task'));
   return (
     <div className="min-h-screen">
       <Navbar />
       <OfflineIndicator />
-      <main className="p-4">
+      <main className="p-4 mx-auto max-w-screen-md">
         <Outlet />
       </main>
       <PwaPrompt />

--- a/src/lib/__tests__/shortcuts.test.ts
+++ b/src/lib/__tests__/shortcuts.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { registerShortcuts } from '../shortcuts';
+
+describe('registerShortcuts', () => {
+  it('calls callback on n key', () => {
+    const cb = vi.fn();
+    const events: Record<string, (e: KeyboardEvent) => void> = {};
+    const win: Pick<Window, 'addEventListener' | 'removeEventListener'> = {
+      addEventListener: vi.fn((t: string, h: (e: KeyboardEvent) => void) => {
+        events[t] = h;
+      }),
+      removeEventListener: vi.fn(),
+    };
+    const cleanup = registerShortcuts(cb, win);
+    events['keydown']?.({
+      key: 'n',
+      ctrlKey: false,
+      metaKey: false,
+      altKey: false,
+      target: { tagName: 'DIV' },
+    } as unknown as KeyboardEvent);
+    expect(cb).toHaveBeenCalled();
+    cleanup();
+    expect(win.removeEventListener).toHaveBeenCalled();
+  });
+
+  it('ignores events from input', () => {
+    const cb = vi.fn();
+    const events: Record<string, (e: KeyboardEvent) => void> = {};
+    const win: Pick<Window, 'addEventListener' | 'removeEventListener'> = {
+      addEventListener: vi.fn((t: string, h: (e: KeyboardEvent) => void) => {
+        events[t] = h;
+      }),
+      removeEventListener: vi.fn(),
+    };
+    registerShortcuts(cb, win);
+    events['keydown']?.({
+      key: 'n',
+      ctrlKey: false,
+      metaKey: false,
+      altKey: false,
+      target: { tagName: 'INPUT' },
+    } as unknown as KeyboardEvent);
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+export function registerShortcuts(
+  onNew: () => void,
+  win: Pick<Window, 'addEventListener' | 'removeEventListener'> = window,
+) {
+  function handler(e: KeyboardEvent) {
+    if (e.key !== 'n' || e.ctrlKey || e.metaKey || e.altKey) return;
+    const target = e.target as HTMLElement | null;
+    const tag = target?.tagName;
+    if (tag && ['INPUT', 'TEXTAREA', 'SELECT'].includes(tag)) return;
+    onNew();
+  }
+  win.addEventListener('keydown', handler);
+  return () => win.removeEventListener('keydown', handler);
+}
+
+export function useKeyboardShortcuts(onNew: () => void) {
+  useEffect(() => registerShortcuts(onNew), [onNew]);
+}


### PR DESCRIPTION
## Summary
- center main content for large screens
- add keyboard shortcut hook
- open task modal with `n` key
- test keyboard shortcuts

## Testing
- `pnpm lint`
- `pnpm test:run`
